### PR TITLE
Add streaming demo pipeline with Kafka, Flink, and FastAPI

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,51 @@
+import os
+from datetime import datetime
+from typing import List, Optional
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+from fastapi import FastAPI, Query
+
+DB_HOST = os.getenv("DB_HOST", "localhost")
+DB_PORT = int(os.getenv("DB_PORT", "5432"))
+DB_NAME = os.getenv("DB_NAME", "inventory")
+DB_USER = os.getenv("DB_USER", "inventory")
+DB_PASSWORD = os.getenv("DB_PASSWORD", "inventory")
+
+app = FastAPI()
+
+
+def get_connection():
+    return psycopg2.connect(
+        host=DB_HOST,
+        port=DB_PORT,
+        dbname=DB_NAME,
+        user=DB_USER,
+        password=DB_PASSWORD,
+    )
+
+
+@app.get("/transactions")
+def read_transactions(
+    warehouse: Optional[str] = Query(default=None),
+    start_date: Optional[datetime] = Query(default=None),
+):
+    conn = get_connection()
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            query = "SELECT * FROM streamed_transactions"
+            params: List[object] = []
+            conditions: List[str] = []
+            if warehouse:
+                conditions.append("warehouse = %s")
+                params.append(warehouse)
+            if start_date:
+                conditions.append("transaction_timestamp >= %s")
+                params.append(start_date)
+            if conditions:
+                query += " WHERE " + " AND ".join(conditions)
+            query += " ORDER BY transaction_timestamp DESC LIMIT 100"
+            cur.execute(query, params)
+            return cur.fetchall()
+    finally:
+        conn.close()

--- a/db/inventory_ddl.sql
+++ b/db/inventory_ddl.sql
@@ -71,3 +71,21 @@ CREATE TABLE inventory_on_hand (
     last_updated TIMESTAMP,
     PRIMARY KEY (part_number, lot_number, warehouse, bin)
 );
+
+-- Table for storing raw streamed transactions from Kafka
+CREATE TABLE streamed_transactions (
+    transaction_id UUID PRIMARY KEY,
+    transaction_type VARCHAR,
+    part_number VARCHAR,
+    lot_number VARCHAR,
+    warehouse VARCHAR,
+    bin VARCHAR,
+    source_facility VARCHAR,
+    destination_facility VARCHAR,
+    quantity INTEGER,
+    unit_cost NUMERIC(10,2),
+    total_cost NUMERIC(12,2),
+    work_order_number VARCHAR,
+    transaction_timestamp TIMESTAMP,
+    created_by INTEGER
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,26 @@
 version: '3.8'
 
-services:
-  postgres:
-    image: postgres:15
-    ports:
-      - "5432:5432"
-    environment:
-      POSTGRES_DB: ${DB_NAME}
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-    volumes:
-      - ./db/inventory_ddl.sql:/docker-entrypoint-initdb.d/inventory_ddl.sql
+networks:
+  streaming:
+    driver: bridge
 
+volumes:
+  zookeeper_data:
+  zookeeper_log:
+  kafka_data:
+  postgres_data:
+
+services:
   zookeeper:
     image: confluentinc/cp-zookeeper:7.4.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
+    volumes:
+      - zookeeper_data:/var/lib/zookeeper/data
+      - zookeeper_log:/var/lib/zookeeper/log
+    networks:
+      - streaming
 
   kafka:
     image: confluentinc/cp-kafka:7.4.0
@@ -27,8 +31,27 @@ services:
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    volumes:
+      - kafka_data:/var/lib/kafka/data
+    networks:
+      - streaming
+
+  postgres:
+    image: postgres:15
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: ${DB_NAME:-inventory}
+      POSTGRES_USER: ${DB_USER:-inventory}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-inventory}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./db/inventory_ddl.sql:/docker-entrypoint-initdb.d/inventory_ddl.sql
+    networks:
+      - streaming
 
   jobmanager:
     image: flink:1.17.1-scala_2.12-java11
@@ -36,48 +59,42 @@ services:
     ports:
       - "8081:8081"
     environment:
-      - |-
+      - |
         FLINK_PROPERTIES=
         jobmanager.rpc.address: jobmanager
     depends_on:
       - kafka
       - postgres
+    networks:
+      - streaming
 
   taskmanager:
     image: flink:1.17.1-scala_2.12-java11
     command: taskmanager
-    depends_on:
-      - jobmanager
     environment:
-      - |-
+      - |
         FLINK_PROPERTIES=
         jobmanager.rpc.address: jobmanager
-
-  producer:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.producer
     depends_on:
-      - kafka
+      - jobmanager
+    networks:
+      - streaming
+
+  api:
+    image: python:3.11-slim
+    working_dir: /app
+    volumes:
+      - ./api:/app
+    command: uvicorn main:app --host 0.0.0.0 --port 8000
+    environment:
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_NAME: ${DB_NAME:-inventory}
+      DB_USER: ${DB_USER:-inventory}
+      DB_PASSWORD: ${DB_PASSWORD:-inventory}
+    depends_on:
       - postgres
-    environment:
-      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
-      DB_HOST: postgres
-      DB_PORT: 5432
-      DB_NAME: ${DB_NAME}
-      DB_USER: ${DB_USER}
-      DB_PASSWORD: ${DB_PASSWORD}
-
-  flink-app:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.flink
-    depends_on:
-      - taskmanager
-    environment:
-      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
-      DB_HOST: postgres
-      DB_PORT: 5432
-      DB_NAME: ${DB_NAME}
-      DB_USER: ${DB_USER}
-      DB_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "8000:8000"
+    networks:
+      - streaming

--- a/flink_jobs/inventory_streaming_job.sql
+++ b/flink_jobs/inventory_streaming_job.sql
@@ -1,0 +1,52 @@
+-- Flink SQL job to read transactions from Kafka and write to PostgreSQL
+
+CREATE TABLE source_transactions (
+    transaction_id STRING,
+    transaction_type STRING,
+    part_number STRING,
+    lot_number STRING,
+    warehouse STRING,
+    bin STRING,
+    source_facility STRING,
+    destination_facility STRING,
+    quantity INT,
+    unit_cost DOUBLE,
+    total_cost DOUBLE,
+    work_order_number STRING,
+    transaction_timestamp TIMESTAMP(3),
+    created_by INT,
+    WATERMARK FOR transaction_timestamp AS transaction_timestamp - INTERVAL '5' SECOND
+) WITH (
+    'connector' = 'kafka',
+    'topic' = 'inventory_transactions',
+    'properties.bootstrap.servers' = 'kafka:9092',
+    'scan.startup.mode' = 'earliest-offset',
+    'format' = 'json'
+);
+
+CREATE TABLE streamed_transactions (
+    transaction_id STRING,
+    transaction_type STRING,
+    part_number STRING,
+    lot_number STRING,
+    warehouse STRING,
+    bin STRING,
+    source_facility STRING,
+    destination_facility STRING,
+    quantity INT,
+    unit_cost DOUBLE,
+    total_cost DOUBLE,
+    work_order_number STRING,
+    transaction_timestamp TIMESTAMP(3),
+    created_by INT,
+    PRIMARY KEY (transaction_id) NOT ENFORCED
+) WITH (
+    'connector' = 'jdbc',
+    'url' = 'jdbc:postgresql://postgres:5432/inventory',
+    'table-name' = 'streamed_transactions',
+    'username' = 'inventory',
+    'password' = 'inventory'
+);
+
+INSERT INTO streamed_transactions
+SELECT * FROM source_transactions;

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ psycopg2-binary
 confluent-kafka
 pyflink
 python-dotenv
+fastapi
+uvicorn

--- a/scripts/kafka_producer.py
+++ b/scripts/kafka_producer.py
@@ -1,0 +1,73 @@
+import json
+import os
+import time
+import uuid
+import random
+from datetime import datetime
+
+from faker import Faker
+from confluent_kafka import Producer
+
+fake = Faker()
+
+KAFKA_BOOTSTRAP_SERVERS = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+KAFKA_TOPIC = os.getenv("KAFKA_TOPIC", "inventory_transactions")
+
+TRANSACTION_TYPES = [
+    "RECEIPT",
+    "ISSUE",
+    "SCRAP",
+    "TRANSFER_IN",
+    "TRANSFER_OUT",
+    "ADJUSTMENT",
+]
+
+
+def generate_transaction():
+    quantity = random.randint(1, 100)
+    unit_cost = round(random.uniform(10.0, 1000.0), 2)
+    return {
+        "transaction_id": str(uuid.uuid4()),
+        "transaction_type": random.choice(TRANSACTION_TYPES),
+        "part_number": f"PART-{random.randint(1000, 9999)}",
+        "lot_number": f"LOT-{random.randint(1000, 9999)}",
+        "warehouse": f"WH{random.randint(1, 5)}",
+        "bin": f"BIN-{random.randint(1, 100)}",
+        "source_facility": f"FAC-{random.randint(1, 5)}",
+        "destination_facility": f"FAC-{random.randint(1, 5)}",
+        "quantity": quantity,
+        "unit_cost": unit_cost,
+        "total_cost": round(quantity * unit_cost, 2),
+        "work_order_number": f"WO-{random.randint(10000, 99999)}",
+        "transaction_timestamp": datetime.utcnow().isoformat(),
+        "created_by": random.randint(1, 10),
+    }
+
+
+def delivery_report(err, msg):
+    if err is not None:
+        print(f"Delivery failed for record {msg.key()}: {err}")
+    else:
+        print(
+            f"Produced record to {msg.topic()} partition {msg.partition()} @ offset {msg.offset()}"
+        )
+
+
+def main():
+    producer = Producer({"bootstrap.servers": KAFKA_BOOTSTRAP_SERVERS})
+    try:
+        while True:
+            transaction = generate_transaction()
+            producer.produce(
+                KAFKA_TOPIC, json.dumps(transaction), callback=delivery_report
+            )
+            producer.poll(0)
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("Stopping producer...")
+    finally:
+        producer.flush()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Set up Docker Compose environment for Kafka, Zookeeper, PostgreSQL, Flink, and FastAPI on a shared network with persistent volumes.
- Added a Kafka producer script that streams synthetic inventory transactions once per second.
- Added a Flink SQL job to write Kafka transactions directly into a PostgreSQL table.
- Exposed a FastAPI endpoint to query the latest 100 transactions with optional filtering.
- Extended database schema and requirements for new services.

## Testing
- `python -m py_compile scripts/kafka_producer.py api/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68926aa6db28832e93cd288a8ee9c682