### PR TITLE
Fix adjustment handling and add tests

### DIFF
--- a/scripts/generate_synthetic_data.py
+++ b/scripts/generate_synthetic_data.py
@@ -191,15 +191,14 @@ def generate_transactions(parts, facilities, work_orders, users, count=1000):
             quantity = qty
             inventory[key] = on_hand - qty
         elif t_type == "ADJUSTMENT":
-            # small adjustments up or down but never negative
+            # small adjustments up or down but never negative inventory
             adj = random.randint(-2, 2)
             if on_hand + adj < 0:
                 adj = -on_hand
-            quantity = abs(adj)
-            t_type = "ADJUSTMENT" if adj >= 0 else "ADJUSTMENT"
+            quantity = adj
             inventory[key] = on_hand + adj
         elif t_type in ("TRANSFER_IN", "TRANSFER_OUT"):
-            # to ensure paired transfers, generate TRANSFER_OUT then TRANSFER_IN
+            # to ensure paired transfers, generate TRANSFER_IN then TRANSFER_OUT
             if on_hand == 0:
                 continue
             qty = min(quantity, on_hand)

--- a/scripts/kafka_producer.py
+++ b/scripts/kafka_producer.py
@@ -5,10 +5,7 @@ import uuid
 import random
 from datetime import datetime
 
-from faker import Faker
 from confluent_kafka import Producer
-
-fake = Faker()
 
 KAFKA_BOOTSTRAP_SERVERS = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
 KAFKA_TOPIC = os.getenv("KAFKA_TOPIC", "inventory_transactions")
@@ -71,3 +68,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import sys
+import random
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_random_seed():
+    random.seed(42)

--- a/tests/test_generate_synthetic_data.py
+++ b/tests/test_generate_synthetic_data.py
@@ -1,0 +1,32 @@
+from scripts.generate_synthetic_data import (
+    generate_part_master,
+    generate_facilities,
+    generate_users,
+    generate_work_orders,
+    generate_transactions,
+)
+
+
+def test_generate_part_master_unique():
+    parts = generate_part_master(10)
+    numbers = [p[0] for p in parts]
+    assert len(numbers) == len(set(numbers)) == 10
+
+
+def test_generate_transactions_inventory_non_negative():
+    parts = generate_part_master()
+    facilities = generate_facilities()
+    users = generate_users()
+    work_orders = generate_work_orders()
+    events, inventory = generate_transactions(parts, facilities, work_orders, users, count=50)
+    assert all(qty >= 0 for qty in inventory.values())
+
+
+def test_generate_transactions_total_cost_matches_quantity():
+    parts = generate_part_master()
+    facilities = generate_facilities()
+    users = generate_users()
+    work_orders = generate_work_orders()
+    events, _ = generate_transactions(parts, facilities, work_orders, users, count=50)
+    for e in events:
+        assert e["total_cost"] == round(e["quantity"] * e["unit_cost"], 2)

--- a/tests/test_kafka_producer.py
+++ b/tests/test_kafka_producer.py
@@ -1,0 +1,6 @@
+from scripts.kafka_producer import generate_transaction
+
+
+def test_generate_transaction_total_cost():
+    tx = generate_transaction()
+    assert tx["total_cost"] == round(tx["quantity"] * tx["unit_cost"], 2)


### PR DESCRIPTION
## Summary
- correct inventory adjustment logic and fix transfer comment
- drop unused Faker dependency and ensure Kafka producer can serialize JSON
- add unit tests for data generation and Kafka producer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892809c4544832ea40d70147a693ef6