### PR TITLE
Expose default Postgres port in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
   postgres:
     image: postgres:15
     ports:
-      - "54321:54321"
+      - "54321:5432"
     environment:
       POSTGRES_DB: ${DB_NAME:-inventory}
       POSTGRES_USER: ${DB_USER:-inventory}


### PR DESCRIPTION
## Summary
- expose container's default Postgres port 5432 while keeping host port 54321

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689284562504832e9c605aecc0003c3e