### PR TITLE
chore: remove unused flink datastream import

### DIFF
--- a/scripts/flink_inventory_processor.py
+++ b/scripts/flink_inventory_processor.py
@@ -1,7 +1,5 @@
 import os
 from pyflink.table import EnvironmentSettings, TableEnvironment
-from pyflink.datastream import StreamExecutionEnvironment
-
 
 KAFKA_BOOTSTRAP_SERVERS = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092")
 KAFKA_TOPIC = os.getenv("KAFKA_TOPIC", "inventory_events")


### PR DESCRIPTION
## Summary
- remove unused `StreamExecutionEnvironment` import from Flink inventory processor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68928457774c832e963adfc2db8f56a8