### PR TITLE
Handle missing event file gracefully in inventory event producer

### DIFF
--- a/scripts/produce_inventory_events.py
+++ b/scripts/produce_inventory_events.py
@@ -18,10 +18,18 @@ def delivery_report(err, msg):
 
 def main():
     producer = Producer({"bootstrap.servers": KAFKA_BOOTSTRAP_SERVERS})
-    with open(EVENT_FILE, "r", encoding="utf-8") as f:
-        for line in f:
-            producer.produce(KAFKA_TOPIC, line.strip(), callback=delivery_report)
-            producer.poll(0)
+    try:
+        with open(EVENT_FILE, "r", encoding="utf-8") as f:
+            for line in f:
+                producer.produce(KAFKA_TOPIC, line.strip(), callback=delivery_report)
+                producer.poll(0)
+    except FileNotFoundError:
+        print(f"Event file '{EVENT_FILE}' not found. Cannot produce events.")
+        return
+    except OSError as err:
+        print(f"Error processing event file '{EVENT_FILE}': {err}")
+        return
+
     producer.flush()
     print("Finished producing events")
 


### PR DESCRIPTION
## Summary
- guard against missing or unreadable event files when producing Kafka inventory events
- log a helpful message and exit instead of raising an exception

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892845860b0832e92bb39ad71705568