### PR TITLE
Use IDENTITY for auto-incrementing IDs

### DIFF
--- a/db/inventory_ddl.sql
+++ b/db/inventory_ddl.sql
@@ -19,14 +19,14 @@ CREATE TABLE facilities (
 );
 
 CREATE TABLE users (
-    user_id SERIAL PRIMARY KEY,
+    user_id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     name VARCHAR NOT NULL,
     email VARCHAR UNIQUE NOT NULL,
     role VARCHAR
 );
 
 CREATE TABLE vendors (
-    vendor_id SERIAL PRIMARY KEY,
+    vendor_id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     name VARCHAR NOT NULL,
     address TEXT,
     contact_email VARCHAR


### PR DESCRIPTION
## Summary
- use `GENERATED ALWAYS AS IDENTITY` for user_id and vendor_id columns in inventory DDL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892845b7c20832e8f15849b573f4e4f